### PR TITLE
Fix GCC warnings

### DIFF
--- a/include/SrcLib_Replacement.h
+++ b/include/SrcLib_Replacement.h
@@ -436,7 +436,7 @@ class char_traits_no_case : public std::char_traits<U16unit>
 public:
 	static int compare(const char_type* s1, const char_type* s2, size_t n)
 	{
-		assert(n < std::numeric_limits<int>::max());
+		assert(static_cast<int>(n) < std::numeric_limits<int>::max());
 		return CompareNoCaseUnicode::CompareNoCaseUTF16(s1, s2, static_cast<int>(n));
 	}
 };

--- a/src/GlotKernel.cpp
+++ b/src/GlotKernel.cpp
@@ -236,7 +236,7 @@ int GlotKernel::XL8(char* buffer, int cap, const char* msgKey, int N) const
 			buffer[0] = '\0';
 		return 0;
 	}
-	if (!this || !mpMsgQuery)
+	if (!mpMsgQuery)
 	{
 		// can't translate unless I have a language.
 		return CopyTextToBuffer(buffer, cap, msgKey, N);


### PR DESCRIPTION
Fix a couple of warnings from gcc 9 on Ubuntu